### PR TITLE
Use a login shell for an entrypoint to allow sourcing user environment variables on login.

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -51,7 +51,7 @@ RUN R -e "devtools::install_github('UrbanInstitute/urbnmapr')"
 RUN pip install awscli --ignore-installed
 
 # Rebuilding lab also takes a long time.
-RUN pip install -U jupyterlab
+RUN pip install jupyterlab==1.0.9
 RUN jupyter labextension install --no-build cityofla-labextension@0.4.3
 RUN jupyter labextension install --no-build @jupyter-widgets/jupyterlab-manager@1.0
 RUN jupyter labextension install --no-build @jupyterlab/geojson-extension@1.0
@@ -111,3 +111,7 @@ USER root
 COPY custom.sh /tmp/custom.sh
 RUN cat /tmp/custom.sh >> /etc/bash.bashrc
 USER $NB_UID
+
+# Use bash login shell for entrypoint in order
+# to automatically source user's .bashrc
+ENTRYPOINT ["bash", "-l", "--"]


### PR DESCRIPTION
Fixes #41. We should make sure to test this on staging before deploying to users.

Since the user `~/.bashrc` will be sourced upon server launch, there is some possibility for users to break things in their environment by putting nefarious code in their `~/.bashrc`. If they are just setting environment variables, it should be okay.